### PR TITLE
Update assistant.md

### DIFF
--- a/docs/essentials/assistant.md
+++ b/docs/essentials/assistant.md
@@ -9,4 +9,4 @@ massCode assistant lives in the tray and gives you the ability to always have qu
 Follow one of the following steps:
 
 - Click on the tray icon
-- Press <kbd>Option+S</kbd>
+- Press <kbd>Option (or Alt) S</kbd>


### PR DESCRIPTION
Some Apple keyboards are localized with an Alt instead of an Option. Removed the '+' as it is not part of the keyboard shortcut.